### PR TITLE
fix an ambiguous compare

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/lib/GitHub/Apps/Auth.pm
+++ b/lib/GitHub/Apps/Auth.pm
@@ -28,44 +28,6 @@ use overload
         return $reverse ?
             _lazy { "$other" . "$self" } :
             _lazy { "$self" . "$other" };
-    },
-    "eq" => sub {
-        my ($self, $other) = @_;
-        return _lazy { "$self" eq "$other" };
-    },
-    "ne" => sub {
-        my ($self, $other) = @_;
-        return _lazy { "$self" ne "$other" };
-    },
-    "lt" => sub {
-        my ($self, $other, $reverse) = @_;
-        return $reverse ?
-            _lazy { "$other" lt "$self" } :
-            _lazy { "$self" lt "$other" };
-    },
-    "le" => sub {
-        my ($self, $other, $reverse) = @_;
-        return $reverse ?
-            _lazy { "$other" le "$self" } :
-            _lazy { "$self" le "$other" };
-    },
-    "gt" => sub {
-        my ($self, $other, $reverse) = @_;
-        return $reverse ?
-            _lazy { "$other" gt "$self" } :
-            _lazy { "$self" gt "$other" };
-    },
-    "ge" => sub {
-        my ($self, $other, $reverse) = @_;
-        return $reverse ?
-            _lazy { "$other" ge "$self" } :
-            _lazy { "$self" ge "$other" };
-    },
-    "cmp" => sub {
-        my ($self, $other, $reverse) = @_;
-        return $reverse ?
-            _lazy { "$other" cmp "$self" } :
-            _lazy { "$self" cmp "$other" };
     };
 
 sub new {
@@ -203,94 +165,11 @@ sub _lazy(&) {
 
 use overload
     '""'   => sub { shift->{sub}->() . "" },
-    "bool" => sub { !!(shift->{sub}->()) },
-    "0+"   => sub { shift->{sub}->() + 0 },
-
     "." => sub {
         my ($self, $other, $reverse) = @_;
         return $reverse ?
             _lazy { "$other" . "$self" } :
             _lazy { "$self" . "$other" };
-    },
-    "!" => sub {
-        my $self = shift;
-        return _lazy { !($self->{sub}->() || 0) },
-    },
-    "eq" => sub {
-        my ($self, $other) = @_;
-        return _lazy { "$self" eq "$other" };
-    },
-    "ne" => sub {
-        my ($self, $other) = @_;
-        return _lazy { "$self" ne "$other" };
-    },
-    "lt" => sub {
-        my ($self, $other, $reverse) = @_;
-        return $reverse ?
-            _lazy { "$other" lt "$self" } :
-            _lazy { "$self" lt "$other" };
-    },
-    "le" => sub {
-        my ($self, $other, $reverse) = @_;
-        return $reverse ?
-            _lazy { "$other" le "$self" } :
-            _lazy { "$self" le "$other" };
-    },
-    "gt" => sub {
-        my ($self, $other, $reverse) = @_;
-        return $reverse ?
-            _lazy { "$other" gt "$self" } :
-            _lazy { "$self" gt "$other" };
-    },
-    "ge" => sub {
-        my ($self, $other, $reverse) = @_;
-        return $reverse ?
-            _lazy { "$other" ge "$self" } :
-            _lazy { "$self" ge "$other" };
-    },
-    "cmp" => sub {
-        my ($self, $other, $reverse) = @_;
-        return $reverse ?
-            _lazy { "$other" cmp "$self" } :
-            _lazy { "$self" cmp "$other" };
-    },
-    "==" => sub {
-        my ($self, $other) = @_;
-        return _lazy { $self->{sub}->() == $other };
-    },
-    "!=" => sub {
-        my ($self, $other) = @_;
-        return _lazy { $self->{sub}->() != $other };
-    },
-    "<" => sub {
-        my ($self, $other, $reverse) = @_;
-        return $reverse ?
-            _lazy { $other < $self->{sub}->() } :
-            _lazy { $self->{sub}->() < $other };
-    },
-    "<=" => sub {
-        my ($self, $other, $reverse) = @_;
-        return $reverse ?
-            _lazy { $other <= $self->{sub}->() } :
-            _lazy { $self->{sub}->() <= $other };
-    },
-    ">" => sub {
-        my ($self, $other, $reverse) = @_;
-        return $reverse ?
-            _lazy { $other > $self->{sub}->() } :
-            _lazy { $self->{sub}->() > $other };
-    },
-    ">=" => sub {
-        my ($self, $other, $reverse) = @_;
-        return $reverse ?
-            _lazy { $other >= $self->{sub}->() } :
-            _lazy { $self->{sub}->() >= $other };
-    },
-    "<=>" => sub {
-        my ($self, $other, $reverse) = @_;
-        return $reverse ?
-            _lazy { $other <=> $self->{sub}->() } :
-            _lazy { $self->{sub}->() <=> $other };
     };
 
 sub new {

--- a/lib/GitHub/Apps/Auth.pm
+++ b/lib/GitHub/Apps/Auth.pm
@@ -34,7 +34,7 @@ use overload
             $new_self->_suffix($new_self->_suffix . $other);
         return $new_self;
     },
-    "eq" => sub { shift->issued_token eq shift };
+    "eq" => sub { $_[0]->issued_token eq "$_[1]" };
 
 sub new {
     my ($class, %args) = @_;

--- a/t/02_overload.t
+++ b/t/02_overload.t
@@ -29,16 +29,27 @@ my $g = mock_guard "GitHub::Apps::Auth" => {
     },
 };
 
-my $hash = { token => $auth };
+my $flag = $auth eq "1234567890";
+my $cmp = $auth cmp "1234567890";
 
-is $auth, "1234567890";
+is "$auth", "1234567890";
+ok $flag;
+ok $cmp == 0;
 sleep 1;
-is $auth, "1234567890";
+is "$auth", "1234567890";
+ok $flag;
+ok $cmp == 0;
 sleep 59;
-is $auth, "1234567890";
+is "$auth", "1234567890";
+ok $flag;
+ok $cmp == 0;
 sleep 1;
-is $auth, "1234567891";
+is "$auth", "1234567891";
+ok !$flag;
+ok $cmp > 0;
 sleep 1;
-is $auth, "1234567891";
+is "$auth", "1234567891";
+ok !$flag;
+ok $cmp > 0;
 
 done_testing;

--- a/t/02_overload.t
+++ b/t/02_overload.t
@@ -29,27 +29,14 @@ my $g = mock_guard "GitHub::Apps::Auth" => {
     },
 };
 
-my $flag = $auth eq "1234567890";
-my $cmp = $auth cmp "1234567890";
-
 is "$auth", "1234567890";
-ok $flag;
-ok $cmp == 0;
 sleep 1;
 is "$auth", "1234567890";
-ok $flag;
-ok $cmp == 0;
 sleep 59;
 is "$auth", "1234567890";
-ok $flag;
-ok $cmp == 0;
 sleep 1;
 is "$auth", "1234567891";
-ok !$flag;
-ok $cmp > 0;
 sleep 1;
 is "$auth", "1234567891";
-ok !$flag;
-ok $cmp > 0;
 
 done_testing;

--- a/t/03_join.t
+++ b/t/03_join.t
@@ -1,8 +1,13 @@
 use strict;
 use Test::More;
+use Test::Mock::Guard;
+use Test::Time;
 
 use GitHub::Apps::Auth;
 use Crypt::PK::RSA;
+use JSON qw/encode_json/;
+use Time::Moment;
+use Furl::Response;
 
 my $pk = Crypt::PK::RSA->new->generate_key->export_key_pem("private");
 
@@ -12,17 +17,40 @@ my $auth = GitHub::Apps::Auth->new(
     installation_id => 4242,
 );
 
-$auth->token("1234567890");
-$auth->expires(time() + 1_000_000_000);
+my $expected_base_token = 1234567890;
+my $g = mock_guard "GitHub::Apps::Auth" => {
+    _post_to_access_token => sub {
+        my $body = encode_json({
+            token => $expected_base_token++ . "",
+            expires_at => Time::Moment->from_epoch(time())->plus_minutes(1)->strftime("%Y-%m-%dT%H:%M:%S%Z"),
+        });
 
-is $auth, "1234567890";
+        return Furl::Response->new(1, 200, "OK", [], $body);
+    },
+};
 
-my $joined_auth = "x-access-token:" . $auth;
+my $joined_auth = "x-access-token: $auth, extra-token: $auth";
+my $flag = $joined_auth eq "x-access-token: 1234567890, extra-token: 1234567890";
+my $cmp = $joined_auth cmp "x-access-token: 1234567890, extra-token: 1234567890";
 
-is $auth, "1234567890";
-is $joined_auth, "x-access-token:1234567890";
-$joined_auth->token("abcdefghijk");
-is $joined_auth, "x-access-token:abcdefghijk";
-is $joined_auth . "\@github.com/owner/repo.git", "x-access-token:abcdefghijk\@github.com/owner/repo.git";
+is "$joined_auth", "x-access-token: 1234567890, extra-token: 1234567890";
+ok $flag;
+ok $cmp == 0;
+sleep 1;
+is "$joined_auth", "x-access-token: 1234567890, extra-token: 1234567890";
+ok $flag;
+ok $cmp == 0;
+sleep 59;
+is "$joined_auth", "x-access-token: 1234567890, extra-token: 1234567890";
+ok $flag;
+ok $cmp == 0;
+sleep 1;
+is "$joined_auth", "x-access-token: 1234567891, extra-token: 1234567891";
+ok !$flag;
+ok $cmp >= 0;
+sleep 1;
+is "$joined_auth", "x-access-token: 1234567891, extra-token: 1234567891";
+ok !$flag;
+ok $cmp >= 0;
 
 done_testing;

--- a/t/03_join.t
+++ b/t/03_join.t
@@ -30,27 +30,15 @@ my $g = mock_guard "GitHub::Apps::Auth" => {
 };
 
 my $joined_auth = "x-access-token: $auth, extra-token: $auth";
-my $flag = $joined_auth eq "x-access-token: 1234567890, extra-token: 1234567890";
-my $cmp = $joined_auth cmp "x-access-token: 1234567890, extra-token: 1234567890";
 
 is "$joined_auth", "x-access-token: 1234567890, extra-token: 1234567890";
-ok $flag;
-ok $cmp == 0;
 sleep 1;
 is "$joined_auth", "x-access-token: 1234567890, extra-token: 1234567890";
-ok $flag;
-ok $cmp == 0;
 sleep 59;
 is "$joined_auth", "x-access-token: 1234567890, extra-token: 1234567890";
-ok $flag;
-ok $cmp == 0;
 sleep 1;
 is "$joined_auth", "x-access-token: 1234567891, extra-token: 1234567891";
-ok !$flag;
-ok $cmp >= 0;
 sleep 1;
 is "$joined_auth", "x-access-token: 1234567891, extra-token: 1234567891";
-ok !$flag;
-ok $cmp >= 0;
 
 done_testing;


### PR DESCRIPTION
This function calls `shift` twice in the same expression.

```perl
"eq" => sub { shift->issued_token eq shift };
```

So, there is two possibilities of evaluating the expression.

```perl
"eq" => sub {
    my $first = shift;
    my $second = shift;
    return $fisrt->issued_token eq $second;
};
```

```perl
"eq" => sub {
    my $first = shift;
    my $second = shift;
    return $second->issued_token eq $fisrt;
};
```

I read the perlop, but the evaluating order is not defined.
https://perldoc.perl.org/5.30.0/perlop.html#Auto-increment-and-Auto-decrement

So we should assume that
there is no guarantee for perl how to evaluate the expression.